### PR TITLE
Fix: range and within func using wrong slice when right+left < nodeSize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/raditzlawliet/kdbush
 
 go 1.20
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helper.go
+++ b/helper.go
@@ -17,7 +17,7 @@ func sort(ids []int, coords []float64, nodeSize, left, right, axis int) {
 
 	m := (left + right) >> 1
 
-	selection(ids, coords, nodeSize, left, right, axis)
+	selection(ids, coords, m, left, right, axis)
 
 	sort(ids, coords, nodeSize, left, m-1, 1-axis)
 	sort(ids, coords, nodeSize, m+1, right, 1-axis)

--- a/kdbush.go
+++ b/kdbush.go
@@ -60,13 +60,13 @@ func (kd *KDBush) Range(minX, minY, maxX, maxY float64) []int {
 	var x, y float64
 
 	for (len(stack)) > 0 {
-		axis := stack[len(stack)-1][0]
+		left := stack[len(stack)-1][0]
 		right := stack[len(stack)-1][1]
-		left := stack[len(stack)-1][2]
+		axis := stack[len(stack)-1][2]
 		stack = append(stack[:len(stack)-1], stack[len(stack):]...) // .pop()
 
 		// search linearly
-		if (right - left) <= kd.nodeSize {
+		if right-left <= kd.nodeSize {
 			for i := left; i <= right; i++ {
 				x = kd.coords[2*i]
 				y = kd.coords[2*i+1]
@@ -104,23 +104,21 @@ func (kd *KDBush) Within(point Point, radius float64) []int {
 	stack := [][]int{{0, len(kd.ids) - 1, 0}}
 	result := []int{}
 
-	// r2 := radius * 2
 	r2 := radius * radius
 
 	qx, qy := point.GetX(), point.GetY()
 	var x, y float64
 
 	for (len(stack)) > 0 {
-		axis := stack[len(stack)-1][0]
+		left := stack[len(stack)-1][0]
 		right := stack[len(stack)-1][1]
-		left := stack[len(stack)-1][2]
+		axis := stack[len(stack)-1][2]
 		stack = append(stack[:len(stack)-1], stack[len(stack):]...) // .pop()
 
 		// search linearly
 		if right-left <= kd.nodeSize {
 			for i := left; i <= right; i++ {
-				a := sqrtDist(kd.coords[2*i], kd.coords[2*i+1], qx, qy)
-				if a <= r2 {
+				if sqrtDist(kd.coords[2*i], kd.coords[2*i+1], qx, qy) <= r2 {
 					result = append(result, kd.ids[i])
 				}
 			}

--- a/kdbush_test.go
+++ b/kdbush_test.go
@@ -38,10 +38,10 @@ var (
 	}
 )
 
-// Test Build Index with more than 1 million point
+// Test Build Index with more than 1k point
 func TestGeneration(t *testing.T) {
 	points2 := []kdbush.Point{}
-	for i := 0; i < 1_000_000; i++ {
+	for i := 0; i < 1_000; i++ {
 		points2 = append(points2, &kdbush.SimplePoint{rand.Float64()*24.0 + 24.0, rand.Float64()*24.0 + 24.0})
 	}
 

--- a/kdbush_test.go
+++ b/kdbush_test.go
@@ -143,7 +143,7 @@ func TestWithin(t *testing.T) {
 // Test Within func with Lower Node Size
 func TestWithinLowNodeSize(t *testing.T) {
 	bush := kdbush.NewBush().
-		BuildIndexWith(points, 16)
+		BuildIndexWith(points, 4)
 
 	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
 

--- a/kdbush_test.go
+++ b/kdbush_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/raditzlawliet/kdbush"
+	"github.com/stretchr/testify/assert"
 )
 
 type testCase struct {
@@ -47,29 +48,13 @@ func TestGeneration(t *testing.T) {
 	bush := kdbush.NewBush().
 		BuildIndexWith(points2, kdbush.STANDARD_NODE_SIZE)
 
-	if len(bush.Points) != len(points2) {
-		t.Fatalf("Kdbush.Point size %v not same with points2 size %v", len(bush.Points), len(points2))
-	}
-
-	for i := range points2 {
-		if points2[i] != bush.Points[i] {
-			t.Fatalf("Index %v Kdbush.Point %v not same with points2  %v", i, bush.Points[i], points[i])
-		}
-	}
+	assert.ElementsMatch(t, bush.Points, points2, "they should be have same elements")
 
 	bush.Add(points2...).
 		BuildIndex(kdbush.STANDARD_NODE_SIZE)
 	points22 := append(points2, points2...)
 
-	if len(bush.Points) != len(points22) {
-		t.Fatalf("Kdbush.Point size %v not same with points22 size %v", len(bush.Points), len(points22))
-	}
-
-	for i := range points22 {
-		if points22[i] != bush.Points[i] {
-			t.Fatalf("Index %v Kdbush.Point %v not same with points22  %v", i, bush.Points[i], points22[i])
-		}
-	}
+	assert.ElementsMatch(t, bush.Points, points22, "they should be have same elements")
 }
 
 // Test Range func
@@ -77,9 +62,7 @@ func TestRange(t *testing.T) {
 	bush := kdbush.NewBush().
 		BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
 
-	if len(bush.Points) != len(points) {
-		t.Fatalf("Kdbush.Point size %v not same with points size %v", len(bush.Points), len(points))
-	}
+	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
 
 	testCases := []testCase{
 		// straight line on x=0
@@ -106,31 +89,18 @@ func TestRange(t *testing.T) {
 		},
 	}
 
-	for i, testCase := range testCases {
+	for _, testCase := range testCases {
 		indexes := bush.Range(testCase.Input[0], testCase.Input[1], testCase.Input[2], testCase.Input[3])
-		if len(indexes) != len(testCase.Index) {
-			t.Fatalf("case index %v test index size %v not same with result index size %v", i, len(testCase.Index), len(indexes))
-		}
-		for k, v := range indexes {
-			if points[v] != testCase.Points[k] {
-				t.Fatalf("case index %v result index %v points %v not same with result points %v by index", i, v, points[v], testCase.Points[k])
-			}
-		}
-		// fmt.Println(indexes)
-		// for _, v := range indexes {
-		// 	fmt.Println(points[v])
-		// }
+		assert.ElementsMatch(t, indexes, testCase.Index, "they should be have same elements")
 	}
 }
 
-// Test WIthin func
+// Test Within func
 func TestWithin(t *testing.T) {
 	bush := kdbush.NewBush().
 		BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
 
-	if len(bush.Points) != len(points) {
-		t.Fatalf("Kdbush.Point size %v not same with points size %v", len(bush.Points), len(points))
-	}
+	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
 
 	testCases := []testCase{
 		// test within inner radius
@@ -164,20 +134,53 @@ func TestWithin(t *testing.T) {
 		},
 	}
 
-	for i, testCase := range testCases {
+	for _, testCase := range testCases {
 		indexes := bush.Within(&kdbush.SimplePoint{testCase.Input[0], testCase.Input[1]}, testCase.Input[2])
-		if len(indexes) != len(testCase.Index) {
-			t.Fatalf("case index %v test index size %v not same with result index size %v", i, len(testCase.Index), len(indexes))
+		assert.ElementsMatch(t, indexes, testCase.Index, "they should be have same elements")
+	}
+}
 
-		}
-		for k, v := range indexes {
-			if points[v] != testCase.Points[k] {
-				t.Fatalf("case index %v result index %v points %v not same with result points %v by index", i, v, points[v], testCase.Points[k])
-			}
-		}
-		// fmt.Println(indexes)
-		// for _, v := range indexes {
-		// 	fmt.Println(points[v])
-		// }
+// Test Within func with Lower Node Size
+func TestWithinLowNodeSize(t *testing.T) {
+	bush := kdbush.NewBush().
+		BuildIndexWith(points, 16)
+
+	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
+
+	testCases := []testCase{
+		// test within inner radius
+		{
+			[]float64{0, 0, 0.999},
+			[]int{0},
+			[]kdbush.Point{
+				points[0],
+			},
+		},
+		// test radius more wide, make sure it's circle (not square)
+		{
+			[]float64{0, 0, 1},
+			[]int{0, 9, 11, 13, 15},
+			[]kdbush.Point{
+				points[0],
+				points[9],
+				points[11],
+				points[13],
+				points[15],
+			},
+		},
+		// test radius not center
+		{
+			[]float64{0.3, 0.2, 0.8},
+			[]int{0, 9},
+			[]kdbush.Point{
+				points[0],
+				points[9],
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		indexes := bush.Within(&kdbush.SimplePoint{testCase.Input[0], testCase.Input[1]}, testCase.Input[2])
+		assert.ElementsMatch(t, indexes, testCase.Index, "they should be have same elements")
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -148,22 +148,21 @@ BenchmarkBuildIndex/total_1000000-20                 134          89170069 ns/op
 ```
 
 Range Benchmark; NodeSize=64
+`go test -bench=BenchmarkRange -benchmem -benchtime=10s`
 
 ```sh
-BenchmarkRange/total_1000-20        790533	      1428 ns/op	     120 B/op	       5 allocs/op
-BenchmarkRange/total_10000-20       795254	      1424 ns/op	     216 B/op	       9 allocs/op
-BenchmarkRange/total_100000-20      647720	      1898 ns/op	     288 B/op	      12 allocs/op
-BenchmarkRange/total_1000000-20     525925	      2313 ns/op	     360 B/op	      15 allocs/op
-ok  	github.com/raditzlawliet/kdbush	7.733s
-
+BenchmarkRange/total_1000-20            65190181               176.3 ns/op           120 B/op          5 allocs/op
+BenchmarkRange/total_10000-20           52118530               228.9 ns/op           216 B/op          9 allocs/op
+BenchmarkRange/total_100000-20          40806165               291.6 ns/op           288 B/op         12 allocs/op
+BenchmarkRange/total_1000000-20         33790890               370.8 ns/op           360 B/op         15 allocs/op
 ```
 
 Within Benchmark; NodeSize=64
+`go test -bench=BenchmarkWithin -benchmem -benchtime=10s`
 
 ```sh
-BenchmarkWithin/total_1000-20       725872	      1524 ns/op	     136 B/op	       6 allocs/op
-BenchmarkWithin/total_10000-20      771256	      1490 ns/op	     232 B/op	      10 allocs/op
-BenchmarkWithin/total_100000-20     619287	      1938 ns/op	     304 B/op	      13 allocs/op
-BenchmarkWithin/total_1000000-20    550041	      2350 ns/op	     376 B/op	      16 allocs/op
-ok  	github.com/raditzlawliet/kdbush	7.747s
+BenchmarkWithin/total_1000-20           61684923               182.4 ns/op           136 B/op          6 allocs/op
+BenchmarkWithin/total_10000-20          50331452               239.6 ns/op           232 B/op         10 allocs/op
+BenchmarkWithin/total_100000-20         39742231               300.8 ns/op           304 B/op         13 allocs/op
+BenchmarkWithin/total_1000000-20        32219763               374.3 ns/op           376 B/op         16 allocs/op
 ```


### PR DESCRIPTION
Additionally: 
- chore: add testify package for testing
- chore: add test lower nodeSize