### PR TITLE
Feat: Optimize and Reducing alloc

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -8,46 +8,21 @@ import (
 	"github.com/raditzlawliet/kdbush"
 )
 
-// Benchmark BuildIndexWith func
-func BenchmarkBuildIndexWith(b *testing.B) {
-	var points = []struct {
-		Points []kdbush.Point
-		Total  int
-	}{
-		{Points: []kdbush.Point{}, Total: 1000},
-		{Points: []kdbush.Point{}, Total: 10_000},
-		{Points: []kdbush.Point{}, Total: 100_000},
-		{Points: []kdbush.Point{}, Total: 1_000_000},
-	}
-
-	// Setup
-	for num := range points {
-		for i := 0; i < points[num].Total; i++ {
-			points[num].Points = append(points[num].Points, &kdbush.SimplePoint{rand.Float64()*24.0 + 24.0, rand.Float64()*24.0 + 24.0})
-		}
-
-	}
-
-	for _, v := range points {
-		b.Run(fmt.Sprintf("total_%d", v.Total), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				kdbush.NewBush().
-					BuildIndexWith(v.Points, kdbush.STANDARD_NODE_SIZE)
-			}
-		})
-	}
-}
-
 // Benchmark BuildIndex func
 func BenchmarkBuildIndex(b *testing.B) {
 	var points = []struct {
-		Points []kdbush.Point
-		Total  int
+		Points   []kdbush.Point
+		Total    int
+		NodeSize int
 	}{
-		{Points: []kdbush.Point{}, Total: 1000},
-		{Points: []kdbush.Point{}, Total: 10_000},
-		{Points: []kdbush.Point{}, Total: 100_000},
-		{Points: []kdbush.Point{}, Total: 1_000_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 1000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 10_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 100_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 1_000_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 1000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 10_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 100_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 1_000_000},
 	}
 
 	// Setup
@@ -59,11 +34,10 @@ func BenchmarkBuildIndex(b *testing.B) {
 	}
 
 	for _, v := range points {
-		b.Run(fmt.Sprintf("total_%d", v.Total), func(b *testing.B) {
+		b.Run(fmt.Sprintf("nodeSize_%d_total_%d", v.NodeSize, v.Total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				kdbush.NewBush().
-					Add(v.Points...).
-					BuildIndex(kdbush.STANDARD_NODE_SIZE)
+					BuildIndex(v.Points, v.NodeSize)
 			}
 		})
 	}
@@ -72,14 +46,23 @@ func BenchmarkBuildIndex(b *testing.B) {
 // Benchmark Range func
 func BenchmarkRange(b *testing.B) {
 	var points = []struct {
-		Points []kdbush.Point
-		Total  int
-		KDBush *kdbush.KDBush
+		Points   []kdbush.Point
+		Total    int
+		KDBush   *kdbush.KDBush
+		NodeSize int
 	}{
-		{Points: []kdbush.Point{}, Total: 1000},
-		{Points: []kdbush.Point{}, Total: 10_000},
-		{Points: []kdbush.Point{}, Total: 100_000},
-		{Points: []kdbush.Point{}, Total: 1_000_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 10},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 100},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 1_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 10_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 100_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 1_000_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 10},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 100},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 1_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 10_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 100_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 1_000_000},
 	}
 
 	// Setup
@@ -88,11 +71,11 @@ func BenchmarkRange(b *testing.B) {
 			points[num].Points = append(points[num].Points, &kdbush.SimplePoint{rand.Float64()*24.0 + 24.0, rand.Float64()*24.0 + 24.0})
 		}
 		points[num].KDBush = kdbush.NewBush().
-			BuildIndexWith(points[num].Points, kdbush.STANDARD_NODE_SIZE)
+			BuildIndex(points[num].Points, points[num].NodeSize)
 	}
 
 	for _, v := range points {
-		b.Run(fmt.Sprintf("total_%d", v.Total), func(b *testing.B) {
+		b.Run(fmt.Sprintf("nodeSize_%d_total_%d", v.NodeSize, v.Total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				v.KDBush.Range(10.0, 10, -10, -10)
 			}
@@ -103,14 +86,23 @@ func BenchmarkRange(b *testing.B) {
 // Benchmark Within func
 func BenchmarkWithin(b *testing.B) {
 	var points = []struct {
-		Points []kdbush.Point
-		Total  int
-		KDBush *kdbush.KDBush
+		Points   []kdbush.Point
+		Total    int
+		KDBush   *kdbush.KDBush
+		NodeSize int
 	}{
-		{Points: []kdbush.Point{}, Total: 1000},
-		{Points: []kdbush.Point{}, Total: 10_000},
-		{Points: []kdbush.Point{}, Total: 100_000},
-		{Points: []kdbush.Point{}, Total: 1_000_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 10},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 100},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 1_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 10_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 100_000},
+		{Points: []kdbush.Point{}, NodeSize: kdbush.STANDARD_NODE_SIZE, Total: 1_000_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 10},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 100},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 1_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 10_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 100_000},
+		{Points: []kdbush.Point{}, NodeSize: 8, Total: 1_000_000},
 	}
 
 	// Setup
@@ -119,13 +111,13 @@ func BenchmarkWithin(b *testing.B) {
 			points[num].Points = append(points[num].Points, &kdbush.SimplePoint{rand.Float64()*24.0 + 24.0, rand.Float64()*24.0 + 24.0})
 		}
 		points[num].KDBush = kdbush.NewBush().
-			BuildIndexWith(points[num].Points, kdbush.STANDARD_NODE_SIZE)
+			BuildIndex(points[num].Points, points[num].NodeSize)
 	}
 
 	for _, v := range points {
-		b.Run(fmt.Sprintf("total_%d", v.Total), func(b *testing.B) {
+		b.Run(fmt.Sprintf("nodeSize_%d_total_%d", v.NodeSize, v.Total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				v.KDBush.Within(&kdbush.SimplePoint{10, 10}, 10)
+				v.KDBush.Within(10, 10, 10)
 			}
 		})
 	}

--- a/geo/test/benchmark_naive_test.go
+++ b/geo/test/benchmark_naive_test.go
@@ -63,7 +63,7 @@ func extract() {
 	}
 }
 
-// Benchmark BuildIndexWith func
+// Benchmark BuildIndex func
 func BenchmarkGeo(b *testing.B) {
 	extract()
 
@@ -119,7 +119,7 @@ func BenchmarkGeo(b *testing.B) {
 	// Benchmark query 1000 closest with different total data
 	for _, v := range cases {
 		bush := kdbush.NewBush().
-			BuildIndexWith(v.Points, kdbush.STANDARD_NODE_SIZE)
+			BuildIndex(v.Points, kdbush.STANDARD_NODE_SIZE)
 
 		b.Run(fmt.Sprintf("AroundClosest1kWithData_%d", v.Total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -131,7 +131,7 @@ func BenchmarkGeo(b *testing.B) {
 	// Benchmark query 50000 closest with different total data
 	for _, v := range cases {
 		bush := kdbush.NewBush().
-			BuildIndexWith(v.Points, kdbush.STANDARD_NODE_SIZE)
+			BuildIndex(v.Points, kdbush.STANDARD_NODE_SIZE)
 
 		b.Run(fmt.Sprintf("AroundClosest5kWithData_%d", v.Total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -143,7 +143,7 @@ func BenchmarkGeo(b *testing.B) {
 	// Benchmark query all data
 	for _, v := range cases {
 		bush := kdbush.NewBush().
-			BuildIndexWith(v.Points, kdbush.STANDARD_NODE_SIZE)
+			BuildIndex(v.Points, kdbush.STANDARD_NODE_SIZE)
 
 		b.Run(fmt.Sprintf("AroundWithData_%d", v.Total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -155,7 +155,7 @@ func BenchmarkGeo(b *testing.B) {
 	// Benchmark query closest random point
 	for _, v := range cases {
 		bush := kdbush.NewBush().
-			BuildIndexWith(v.Points, kdbush.STANDARD_NODE_SIZE)
+			BuildIndex(v.Points, kdbush.STANDARD_NODE_SIZE)
 
 		index := rand.Intn(len(v.Points))
 

--- a/geo/test/geo_test.go
+++ b/geo/test/geo_test.go
@@ -36,9 +36,7 @@ func TestDistance(t *testing.T) {
 
 func TestSimpleAround(t *testing.T) {
 	bush := kdbush.NewBush().
-		BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
-
-	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
+		BuildIndex(points, kdbush.STANDARD_NODE_SIZE)
 
 	testCases := []struct {
 		Name         string
@@ -104,9 +102,7 @@ func TestSimpleAround(t *testing.T) {
 
 func TestAroundWithDifferentNodeSize(t *testing.T) {
 	bush := kdbush.NewBush().
-		BuildIndexWith(points, 4)
-
-	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
+		BuildIndex(points, 4)
 
 	testCases := []struct {
 		Name         string

--- a/kdbush.go
+++ b/kdbush.go
@@ -6,43 +6,27 @@ const STANDARD_NODE_SIZE = 64
 
 // KDBush an instance
 type KDBush struct {
-	Points []Point // pointer
-
-	// avoid change on-the-fly
 	nodeSize int
 	ids      []int
 	coords   []float64
+	indexed  bool
 }
 
 // NewBush return a new pointer of [KDBush]
 func NewBush() *KDBush {
-	kd := KDBush{
-		Points: []Point{},
-	}
+	kd := KDBush{}
 	return &kd
 }
 
-// Add will add a new pointer point to KDBush instance. This function accept variadic param and return this pointer of KDBush
-func (kd *KDBush) Add(points ...Point) *KDBush {
-	kd.Points = append(kd.Points, points...)
-	return kd
-}
-
-// BuildIndexWith will rebuild a new kdtree index with passed []Point with nodeSize.
-// It will throw away previously process [KDBush.Add] and [KDBush.BuildIndex] and replace with the new index.
-func (kd *KDBush) BuildIndexWith(points []Point, nodeSize int) *KDBush {
-	kd.Points = points
-	return kd.BuildIndex(nodeSize)
-}
-
-// BuildIndex will rebuild a new kdtree index with saved Point from [KDBush.Add] or even latest [KDBush.BuildIndexWith] (if any) with [nodeSize].
-func (kd *KDBush) BuildIndex(nodeSize int) *KDBush {
+// BuildIndex bulding kd-tree index given list of Points
+func (kd *KDBush) BuildIndex(points []Point, nodeSize int) *KDBush {
+	kd.indexed = false
 	kd.nodeSize = nodeSize
 
-	kd.ids = make([]int, len(kd.Points))
-	kd.coords = make([]float64, 2*len(kd.Points))
+	kd.ids = make([]int, len(points))
+	kd.coords = make([]float64, 2*len(points))
 
-	for i, v := range kd.Points {
+	for i, v := range points {
 		kd.ids[i] = i
 		kd.coords[i*2] = v.GetX()
 		kd.coords[i*2+1] = v.GetY()
@@ -50,20 +34,32 @@ func (kd *KDBush) BuildIndex(nodeSize int) *KDBush {
 
 	sort(kd.ids, kd.coords, kd.nodeSize, 0, len(kd.ids)-1, 0)
 
+	kd.indexed = true
 	return kd
 }
 
-// Range will return indexes all points across [minX], [minY], [maxX], [maxY]
+// query helper struct for API Range & Within finding result
+type query struct {
+	left  int
+	right int
+	axis  int
+}
+
+// Range will return all indexes points across [minX], [minY], [maxX], [maxY]
 func (kd *KDBush) Range(minX, minY, maxX, maxY float64) []int {
-	stack := [][]int{{0, len(kd.ids) - 1, 0}}
+	if !kd.indexed {
+		return []int{}
+	}
+
+	stack := []query{{0, len(kd.ids) - 1, 0}}
 	result := []int{}
 
 	var x, y float64
 
 	for (len(stack)) > 0 {
-		left := stack[len(stack)-1][0]
-		right := stack[len(stack)-1][1]
-		axis := stack[len(stack)-1][2]
+		left := stack[len(stack)-1].left
+		right := stack[len(stack)-1].right
+		axis := stack[len(stack)-1].axis
 		stack = append(stack[:len(stack)-1], stack[len(stack):]...) // .pop()
 
 		// search linearly
@@ -90,30 +86,33 @@ func (kd *KDBush) Range(minX, minY, maxX, maxY float64) []int {
 
 		// queue search in halves that intersect the query
 		if (axis == 0 && minX <= x) || (axis != 0 && minY <= y) {
-			stack = append(stack, []int{left, m - 1, 1 - axis})
+			stack = append(stack, query{left, m - 1, 1 - axis})
 		}
 		if (axis == 0 && maxX >= x) || (axis != 0 && maxY >= y) {
-			stack = append(stack, []int{m + 1, right, 1 - axis})
+			stack = append(stack, query{m + 1, right, 1 - axis})
 		}
 	}
 
 	return result
 }
 
-// Within will return indexes all point within radius of given single [Point]
-func (kd *KDBush) Within(point Point, radius float64) []int {
-	stack := [][]int{{0, len(kd.ids) - 1, 0}}
+// Within will return all indexes points within radius of given single [Point]
+func (kd *KDBush) Within(qx, qy float64, radius float64) []int {
+	if !kd.indexed {
+		return []int{}
+	}
+
+	stack := []query{{0, len(kd.ids) - 1, 0}}
 	result := []int{}
 
 	r2 := radius * radius
 
-	qx, qy := point.GetX(), point.GetY()
 	var x, y float64
 
 	for (len(stack)) > 0 {
-		left := stack[len(stack)-1][0]
-		right := stack[len(stack)-1][1]
-		axis := stack[len(stack)-1][2]
+		left := stack[len(stack)-1].left
+		right := stack[len(stack)-1].right
+		axis := stack[len(stack)-1].axis
 		stack = append(stack[:len(stack)-1], stack[len(stack):]...) // .pop()
 
 		// search linearly
@@ -138,24 +137,36 @@ func (kd *KDBush) Within(point Point, radius float64) []int {
 
 		// queue search in halves that intersect the query
 		if (axis == 0 && qx-radius <= x) || (axis != 0 && qy-radius <= y) {
-			stack = append(stack, []int{left, m - 1, 1 - axis})
+			stack = append(stack, query{left, m - 1, 1 - axis})
 		}
 		if (axis == 0 && qx+radius >= x) || (axis != 0 && qy+radius >= y) {
-			stack = append(stack, []int{m + 1, right, 1 - axis})
+			stack = append(stack, query{m + 1, right, 1 - axis})
 		}
 	}
 
 	return result
 }
 
+//
+// Helper get private param
+//
+
+// GetNodeSize return current nodesize
 func (kd *KDBush) GetNodeSize() int {
 	return kd.nodeSize
 }
 
+// GetIndexed return all kdtree indexes
 func (kd *KDBush) GetIndexes() []int {
 	return kd.ids
 }
 
+// GetCoords return all coords
 func (kd *KDBush) GetCoords() []float64 {
 	return kd.coords
+}
+
+// Indexed return it's KDBush already indexed or not
+func (kd *KDBush) Indexed() bool {
+	return kd.indexed
 }

--- a/kdbush_test.go
+++ b/kdbush_test.go
@@ -45,24 +45,60 @@ func TestGeneration(t *testing.T) {
 		points2 = append(points2, &kdbush.SimplePoint{rand.Float64()*24.0 + 24.0, rand.Float64()*24.0 + 24.0})
 	}
 
-	bush := kdbush.NewBush().
-		BuildIndexWith(points2, kdbush.STANDARD_NODE_SIZE)
+	bush := kdbush.NewBush()
+	assert.Equal(t, bush.Indexed(), false, "should not indexed")
+	assert.Equal(t, bush.Within(0, 0, 0), []int{}, "should return empty slice of int")
+	assert.Equal(t, bush.Range(-5, 0, 5, 0), []int{}, "should return empty slice of int")
 
-	assert.ElementsMatch(t, bush.Points, points2, "they should be have same elements")
+	bush.BuildIndex(points2, kdbush.STANDARD_NODE_SIZE)
 
-	bush.Add(points2...).
-		BuildIndex(kdbush.STANDARD_NODE_SIZE)
-	points22 := append(points2, points2...)
-
-	assert.ElementsMatch(t, bush.Points, points22, "they should be have same elements")
+	assert.Equal(t, len(bush.GetIndexes()), len(points2), "they should be have same length")
+	assert.Equal(t, bush.GetNodeSize(), kdbush.STANDARD_NODE_SIZE, "nodesize should be same")
+	assert.Equal(t, bush.Indexed(), true, "should indexed")
+	assert.Equal(t, len(bush.GetIndexes()), len(points2), "indexes length should same with points")
+	assert.Equal(t, len(bush.GetCoords()), len(points2)*2, "coords length should 2x with points")
 }
 
 // Test Range func
 func TestRange(t *testing.T) {
 	bush := kdbush.NewBush().
-		BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
+		BuildIndex(points, kdbush.STANDARD_NODE_SIZE)
 
-	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
+	testCases := []testCase{
+		// straight line on x=0
+		{
+			[]float64{-2.1, 0.0, 2.1, 0},
+			[]int{0, 9, 10, 11, 12},
+			[]kdbush.Point{
+				points[0],
+				points[9],
+				points[10],
+				points[11],
+				points[12],
+			},
+		},
+		// straight line on x=1.0
+		{
+			[]float64{-2.1, 1.0, 2.1, 1.0},
+			[]int{2, 8, 13},
+			[]kdbush.Point{
+				points[2],
+				points[8],
+				points[13],
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		indexes := bush.Range(testCase.Input[0], testCase.Input[1], testCase.Input[2], testCase.Input[3])
+		assert.ElementsMatch(t, indexes, testCase.Index, "they should be have same elements")
+	}
+}
+
+// Test Range func
+func TestRangeLowerNodeSize(t *testing.T) {
+	bush := kdbush.NewBush().
+		BuildIndex(points, 4)
 
 	testCases := []testCase{
 		// straight line on x=0
@@ -98,9 +134,7 @@ func TestRange(t *testing.T) {
 // Test Within func
 func TestWithin(t *testing.T) {
 	bush := kdbush.NewBush().
-		BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
-
-	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
+		BuildIndex(points, kdbush.STANDARD_NODE_SIZE)
 
 	testCases := []testCase{
 		// test within inner radius
@@ -135,7 +169,7 @@ func TestWithin(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		indexes := bush.Within(&kdbush.SimplePoint{testCase.Input[0], testCase.Input[1]}, testCase.Input[2])
+		indexes := bush.Within(testCase.Input[0], testCase.Input[1], testCase.Input[2])
 		assert.ElementsMatch(t, indexes, testCase.Index, "they should be have same elements")
 	}
 }
@@ -143,9 +177,7 @@ func TestWithin(t *testing.T) {
 // Test Within func with Lower Node Size
 func TestWithinLowNodeSize(t *testing.T) {
 	bush := kdbush.NewBush().
-		BuildIndexWith(points, 4)
-
-	assert.ElementsMatch(t, bush.Points, points, "they should be have same elements")
+		BuildIndex(points, 4)
 
 	testCases := []testCase{
 		// test within inner radius
@@ -180,7 +212,7 @@ func TestWithinLowNodeSize(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		indexes := bush.Within(&kdbush.SimplePoint{testCase.Input[0], testCase.Input[1]}, testCase.Input[2])
+		indexes := bush.Within(testCase.Input[0], testCase.Input[1], testCase.Input[2])
 		assert.ElementsMatch(t, indexes, testCase.Index, "they should be have same elements")
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ A very fast static spatial index for 2D points based on a flat KD-tree and almos
 - 2 Dimensional Points only — no rectangles.
 - Static — you can't add/remove items after initial indexing (You need to rebuild index)
 - Faster indexing and search, with lower memory footprint
-- Build-in API with **Zero-Allocation** (See [#Benchmark](#benchmark))
+- Build-in API with almost **Zero-Allocation** (See [#Benchmark](#benchmark))
   - Range: return indexes within 2 point
   - Within: return indexes within radius of point
 

--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,12 @@
 
 Golang KD-Bush implementation
 
-A very fast static spatial index for 2D points based on a flat KD-tree
+A very fast static spatial index for 2D points based on a flat KD-tree and almost Zero-Allocation
 
 - 2 Dimensional Points only — no rectangles.
 - Static — you can't add/remove items after initial indexing (You need to rebuild index)
 - Faster indexing and search, with lower memory footprint
-- Build-in feat
+- Build-in API with **Zero-Allocation** (See [#Benchmark](#benchmark))
   - Range: return indexes within 2 point
   - Within: return indexes within radius of point
 
@@ -83,7 +83,7 @@ points = []kdbush.Point{
 
 // 1. Build Index (prefered way)
 bush := kdbush.NewBush().
-    BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
+    BuildIndex(points, kdbush.STANDARD_NODE_SIZE)
 
 // Ready to use
 // API Range
@@ -91,39 +91,58 @@ indexes := bush.Range(-2.1, 1.0, 2.1, 1.0)
 // [2 8 13]
 for _, v := range indexes {
   fmt.Println(points[v])
-  fmt.Println(bush.Points[v]) // or
 }
 // &{1 1} &{-1 1} &{0 1}
 
-// API Within Radius
-indexes := bush.Within(&kdbush.SimplePoint{0, 0}, 1)
+// API Within X, Y with Radius
+indexes := bush.Within(0, 0, 1)
 // [0 9 11 13 15]
 for _, v := range indexes {
   fmt.Println(points[v])
-  fmt.Println(bush.Points[v]) // or
 }
 // &{0 0} &{1 0} &{-1 0} &{0 1} &{0 -1}
 
 ```
 
-You also can use variadic param when adding points. it will use more alloc, but some case may need it.
-Since index are static. if you need add new point for some case, you can add Index using Add() and rebuild index using BuildIndex()
+kDBush library didn't store original slices to avoid duplication slice
+
+Since index are static. if you need rebuild or adding new point for some case, you can call BuildIndex() multiple times.
 _Keep in mind, you will need more resources to rebuild..._
 
 ```go
-// Build Index using variadic version (use more alloc)
 bush := kdbush.NewBush().
-    Add(points...).
-    BuildIndex(kdbush.STANDARD_NODE_SIZE)
-
-// Other example
-bush := kdbush.NewBush().
-    BuildIndexWith(points, kdbush.STANDARD_NODE_SIZE)
-for _, v := range newPoints {
-    Add(v)
-}
-bush.BuildIndex(kdbush.STANDARD_NODE_SIZE)
+  BuildIndex(points, kdbush.STANDARD_NODE_SIZE)
+points.Add(newPoint)
+bush.BuildIndex(points, kdbush.STANDARD_NODE_SIZE)
 ```
+
+To avoid datarace on concurrency, please make sure lock bush when build index and you also can check it's already indexed or not via KDBush.Indexed()
+
+## API
+
+### BuildIndex(points, nodeSize) \*KDBush
+
+bulding kd-tree index given list of `points` and `nodeSize`, and return `*KDBush`
+
+- `points`: list Point interface `[]Point`
+- `nodeSize`: kd-tree node size. Standard Node Size is 64. Higher value means faster indexing but slower search and vice versa. `int`
+
+### Range(minX, minY, maxX, maxY) []int
+
+return all indexes points across 2 point `minX`, `minY`, `maxX`, `maxY`
+
+- `minX`: point X of A `float64`
+- `minY`: point Y of A `float64`
+- `maxX`: point X of B `float64`
+- `maxY`: point Y of B `float64`
+
+### Within(x, y, radius) []int
+
+return all indexes points within `radius` of given single point `x`, `y`
+
+- `x`: X point `float64`
+- `y`: Y point `float64`
+- `radius`: radius to search within `float64`
 
 ## Benchmark
 
@@ -131,42 +150,41 @@ All benchmark are run on Go 1.20.3, Windows 11 & 12th Gen Intel(R) Core(TM) i7-1
 
 **Do not trust benchmark**
 
-`go test -bench=BenchmarkBuildIndex -benchmem -benchtime=10s`
+`go test -bench=. -benchmem -benchtime=10s`
 
-Build Index With Benchmark (-benchtime=10s); NodeSize=64
-
-```sh
-BenchmarkBuildIndexWith/total_1000-20             775942             15443 ns/op           24576 B/op          2 allocs/op
-BenchmarkBuildIndexWith/total_10000-20             22734            522197 ns/op          245760 B/op          2 allocs/op
-BenchmarkBuildIndexWith/total_100000-20             1813           6551473 ns/op         2408448 B/op          2 allocs/op
-BenchmarkBuildIndexWith/total_1000000-20             146          84477151 ns/op        24010752 B/op          2 allocs/op
-```
-
-Build Index (Variadic with Add) Benchmark (-benchtime=10s); NodeSize=64
+Benchmark (-benchtime=10s); NodeSize=64
 
 ```sh
-BenchmarkBuildIndex/total_1000-20                 654110             17228 ns/op           40960 B/op          3 allocs/op
-BenchmarkBuildIndex/total_10000-20                 23164            520225 ns/op          409600 B/op          3 allocs/op
-BenchmarkBuildIndex/total_100000-20                 1587           7685670 ns/op         4014080 B/op          3 allocs/op
-BenchmarkBuildIndex/total_1000000-20                 134          89170069 ns/op        40017920 B/op          3 allocs/op
-```
-
-Range Benchmark; NodeSize=64
-`go test -bench=BenchmarkRange -benchmem -benchtime=10s`
-
-```sh
-BenchmarkRange/total_1000-20            65190181               176.3 ns/op           120 B/op          5 allocs/op
-BenchmarkRange/total_10000-20           52118530               228.9 ns/op           216 B/op          9 allocs/op
-BenchmarkRange/total_100000-20          40806165               291.6 ns/op           288 B/op         12 allocs/op
-BenchmarkRange/total_1000000-20         33790890               370.8 ns/op           360 B/op         15 allocs/op
-```
-
-Within Benchmark; NodeSize=64
-`go test -bench=BenchmarkWithin -benchmem -benchtime=10s`
-
-```sh
-BenchmarkWithin/total_1000-20           61684923               182.4 ns/op           136 B/op          6 allocs/op
-BenchmarkWithin/total_10000-20          50331452               239.6 ns/op           232 B/op         10 allocs/op
-BenchmarkWithin/total_100000-20         39742231               300.8 ns/op           304 B/op         13 allocs/op
-BenchmarkWithin/total_1000000-20        32219763               374.3 ns/op           376 B/op         16 allocs/op
+BenchmarkBuildIndex/nodeSize_64_total_1000-20             566725             20356 ns/op           24576 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_64_total_10000-20             13802            876863 ns/op          245760 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_64_total_100000-20             1122          10741001 ns/op         2408451 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_64_total_1000000-20             100         122507051 ns/op        24010786 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_8_total_1000-20              181689             66618 ns/op           24576 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_8_total_10000-20              10000           1151113 ns/op          245760 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_8_total_100000-20               805          14646166 ns/op         2408448 B/op          2 allocs/op
+BenchmarkBuildIndex/nodeSize_8_total_1000000-20               72         161955225 ns/op        24010752 B/op          2 allocs/op
+BenchmarkRange/nodeSize_64_total_10-20                  839765822               14.11 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_64_total_100-20                 157284577               76.62 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_64_total_1000-20                100000000              100.4 ns/op             0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_64_total_10000-20               165987278               72.31 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_64_total_100000-20              125252017               97.03 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_64_total_1000000-20             97950468               125.1 ns/op             0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_8_total_10-20                   1000000000               8.681 ns/op           0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_8_total_100-20                  696466574               17.35 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_8_total_1000-20                 460818502               26.25 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_8_total_10000-20                303527074               39.56 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_8_total_100000-20               243663084               48.67 ns/op            0 B/op          0 allocs/op
+BenchmarkRange/nodeSize_8_total_1000000-20              194835972               60.02 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_64_total_10-20                 984755572               12.07 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_64_total_100-20                176766757               67.20 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_64_total_1000-20               134922337               89.54 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_64_total_10000-20              192972932               62.07 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_64_total_100000-20             151349331               79.71 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_64_total_1000000-20            100000000              101.4 ns/op             0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_8_total_10-20                  1000000000               8.625 ns/op           0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_8_total_100-20                 612873906               19.54 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_8_total_1000-20                425276205               27.61 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_8_total_10000-20               302259685               40.02 ns/op            0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_8_total_100000-20              100000000              136.8 ns/op             0 B/op          0 allocs/op
+BenchmarkWithin/nodeSize_8_total_1000000-20             203591168               56.46 ns/op            0 B/op          0 allocs/op
 ```


### PR DESCRIPTION
Before
```sh
BenchmarkBuildIndex/total_1000-20                 654110             17228 ns/op           40960 B/op          3 allocs/op
BenchmarkBuildIndex/total_10000-20                 23164            520225 ns/op          409600 B/op          3 allocs/op
BenchmarkBuildIndex/total_100000-20                 1587           7685670 ns/op         4014080 B/op          3 allocs/op
BenchmarkBuildIndex/total_1000000-20                 134          89170069 ns/op        40017920 B/op          3 allocs/op
BenchmarkWithin/total_1000-20           61684923               182.4 ns/op           136 B/op          6 allocs/op
BenchmarkWithin/total_10000-20          50331452               239.6 ns/op           232 B/op         10 allocs/op
BenchmarkWithin/total_100000-20         39742231               300.8 ns/op           304 B/op         13 allocs/op
BenchmarkWithin/total_1000000-20        32219763               374.3 ns/op           376 B/op         16 allocs/op
```

After
```sh
BenchmarkRange/nodeSize_64_total_10-20                  839765822               14.11 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_64_total_100-20                 157284577               76.62 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_64_total_1000-20                100000000              100.4 ns/op             0 B/op          0 allocs/op
BenchmarkRange/nodeSize_64_total_10000-20               165987278               72.31 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_64_total_100000-20              125252017               97.03 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_64_total_1000000-20             97950468               125.1 ns/op             0 B/op          0 allocs/op
BenchmarkRange/nodeSize_8_total_10-20                   1000000000               8.681 ns/op           0 B/op          0 allocs/op
BenchmarkRange/nodeSize_8_total_100-20                  696466574               17.35 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_8_total_1000-20                 460818502               26.25 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_8_total_10000-20                303527074               39.56 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_8_total_100000-20               243663084               48.67 ns/op            0 B/op          0 allocs/op
BenchmarkRange/nodeSize_8_total_1000000-20              194835972               60.02 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_64_total_10-20                 984755572               12.07 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_64_total_100-20                176766757               67.20 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_64_total_1000-20               134922337               89.54 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_64_total_10000-20              192972932               62.07 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_64_total_100000-20             151349331               79.71 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_64_total_1000000-20            100000000              101.4 ns/op             0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_8_total_10-20                  1000000000               8.625 ns/op           0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_8_total_100-20                 612873906               19.54 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_8_total_1000-20                425276205               27.61 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_8_total_10000-20               302259685               40.02 ns/op            0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_8_total_100000-20              100000000              136.8 ns/op             0 B/op          0 allocs/op
BenchmarkWithin/nodeSize_8_total_1000000-20             203591168               56.46 ns/op            0 B/op          0 allocs/op
```