### PR TITLE
Fix unnecessary lint.

### DIFF
--- a/geo/geo.go
+++ b/geo/geo.go
@@ -48,7 +48,7 @@ func Around(bush *kdbush.KDBush, lng, lat float64, maxResults int, maxDistanceIn
 			// add all points of the leaf node to the queue
 			for i := left; i <= right; i++ {
 				itemId := bush.GetIndexes()[i]
-				if predicate == nil || (predicate != nil && predicate(itemId)) {
+				if predicate == nil || predicate(itemId) {
 					heap.Push(&q, &geoNode{
 						itemID: nullInt{itemId, true},
 						dist:   haverSinDist(lng, lat, bush.GetCoords()[2*i], bush.GetCoords()[2*i+1], cosLat),
@@ -64,7 +64,7 @@ func Around(bush *kdbush.KDBush, lng, lat float64, maxResults int, maxDistanceIn
 
 			// add middle point to the queue
 			itemId := bush.GetIndexes()[mid]
-			if predicate == nil || (predicate != nil && predicate(itemId)) {
+			if predicate == nil || predicate(itemId) {
 				heap.Push(&q, &geoNode{
 					itemID: nullInt{itemId, true},
 					dist:   haverSinDist(lng, lat, midLng, midLat, cosLat),

--- a/geo/geo_benchmark_test.go
+++ b/geo/geo_benchmark_test.go
@@ -175,7 +175,7 @@ func BenchmarkGeo(b *testing.B) {
 	index2 := rng.Intn(len(cases[len(cases)-1].Points))
 	point2 := cases[len(cases)-1].Points[index2]
 
-	b.Run(fmt.Sprintf("Distance"), func(b *testing.B) {
+	b.Run("Distance", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			geo.Distance(point1.GetX(), point1.GetY(), point2.GetX(), point2.GetY())
 		}

--- a/geo/readme.md
+++ b/geo/readme.md
@@ -72,9 +72,7 @@ Returns great circle distance between two locations in kilometers.
 
 ## Benchmark
 
-All benchmark are run on Go 1.20.3, Windows 11 & 12th Gen Intel(R) Core(TM) i7-12700H (Laptop version).
-
-**Do not trust benchmark**
+All benchmark are run on Go 1.20.3, Windows 11 & 12th Gen Intel(R) Core(TM) i7-12700H (Laptop version). **Do not trust benchmark**
 
 `go test -bench=BenchmarkGeo -benchmem`
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/raditzlawliet/kdbush
 
-go 1.24
+go 1.18
 
 require github.com/stretchr/testify v1.11.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/raditzlawliet/kdbush
 
-go 1.20
+go 1.24
 
-require github.com/stretchr/testify v1.8.4
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/readme.md
+++ b/readme.md
@@ -39,21 +39,21 @@ Before building index, you need to create list of Points by implement Point inte
 ```go
 // Point interface
 type Point interface {
-	GetX() (X float64)
-	GetY() (Y float64)
+  GetX() (X float64)
+  GetY() (Y float64)
 }
 
 // Example Simple Point implement Point Interface
 type SimplePoint struct {
-	X, Y float64
+  X, Y float64
 }
 
 func (p *SimplePoint) GetX() (X float64) {
-	return p.X
+  return p.X
 }
 
 func (p *SimplePoint) GetY() (Y float64) {
-	return p.Y
+  return p.Y
 }
 ```
 
@@ -146,9 +146,7 @@ return all indexes points within `radius` of given single point `x`, `y`
 
 ## Benchmark
 
-All benchmark are run on Go 1.20.3, Windows 11 & 12th Gen Intel(R) Core(TM) i7-12700H (Laptop version).
-
-**Do not trust benchmark**
+All benchmark are run on Go 1.20.3, Windows 11 & 12th Gen Intel(R) Core(TM) i7-12700H (Laptop version). **Do not trust benchmark**
 
 `go test -bench=. -benchmem`
 


### PR DESCRIPTION
This pull request consists of small improvements and maintenance updates across the codebase, focusing on code clarity, dependency updates, and documentation formatting.

Dependency and compatibility updates:

* Downgraded the Go module version from 1.20 to 1.18 in `go.mod` to increase compatibility, and updated the `testify` dependency to version 1.11.1.

Code clarity and simplification:

* Simplified predicate checks in the `Around` function in `geo/geo.go` by removing redundant conditions, making the code easier to read and maintain. [[1]](diffhunk://#diff-f5e6f3f6a246f20de2cc286714ffc58a4a013bac998d0adb0157a1fdb9c3a5e5L51-R51) [[2]](diffhunk://#diff-f5e6f3f6a246f20de2cc286714ffc58a4a013bac998d0adb0157a1fdb9c3a5e5L67-R67)
* Cleaned up the benchmark test in `geo/geo_benchmark_test.go` by removing unnecessary `fmt.Sprintf` usage in the subtest name.

Documentation formatting:

* Improved the formatting of benchmark information in both `geo/readme.md` and `readme.md` by consolidating lines for better readability. [[1]](diffhunk://#diff-775576091c84a89b8c0c07dd5ec7bc4a3598983460987f972efe8fc332c8ef28L75-R75) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L149-R149)This pull request includes minor improvements to the `geo` package, focusing on simplifying predicate checks, updating dependencies, and making small documentation and benchmark updates.

Code simplification and bugfixes:
* Simplified the predicate checks in the `Around` function in `geo.go` by removing unnecessary redundancy in conditional statements. [[1]](diffhunk://#diff-f5e6f3f6a246f20de2cc286714ffc58a4a013bac998d0adb0157a1fdb9c3a5e5L51-R51) [[2]](diffhunk://#diff-f5e6f3f6a246f20de2cc286714ffc58a4a013bac998d0adb0157a1fdb9c3a5e5L67-R67)

Dependency and compatibility updates:
* Updated the Go version in `go.mod` from 1.20 to 1.24 and bumped the `testify` dependency from v1.8.4 to v1.11.1 for improved compatibility and testing features.

Documentation and benchmark improvements:
* Combined sentences in the benchmark sections of `readme.md` and `geo/readme.md` for clarity and conciseness. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L149-R149) [[2]](diffhunk://#diff-775576091c84a89b8c0c07dd5ec7bc4a3598983460987f972efe8fc332c8ef28L75-R75)
* Minor cleanup of benchmark test naming in `geo_benchmark_test.go` for consistency.Remove tautological warning on geo.
update go mod for testify module.